### PR TITLE
rename to asciidoc; format greenline as heading

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
 greenline README
+----------------
 
 Greenline is an agnostic relay for interconnecting disparate components. It is
 named after the oldest subway line of the same name in Boston, Massachusetts.


### PR DESCRIPTION
This commit sets the README format to asciidoc.
